### PR TITLE
Release 0.4

### DIFF
--- a/tests/testdata/README.md
+++ b/tests/testdata/README.md
@@ -1,1 +1,1 @@
-Contract manually built from https://github.com/osmosis-labs/mesh-security/tree/main/contracts 
+Contract manually built from https://github.com/babylonlabs-io/babylon-contract/tree/main/contracts


### PR DESCRIPTION
Tagging a version with the (manually built) v0.8.0 version of the contracts.