### PR TITLE
F/rewards generation 2

### DIFF
--- a/x/babylon/contract/in_message.go
+++ b/x/babylon/contract/in_message.go
@@ -1,11 +1,18 @@
 package contract
 
-// CustomMsg is a message sent from a smart contract to the Babylon module
-// TODO: implement
-type CustomMsg struct {
-	Test *TestMsg `json:"test,omitempty"`
-}
+import (
+	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
+)
 
-type TestMsg struct {
-	Placeholder string `json:"placeholder,omitempty"`
-}
+// CustomMsg is a message sent from a smart contract to the Babylon module
+type (
+	CustomMsg struct {
+		MintRewards *MintRewardsMsg `json:"mint_rewards,omitempty"`
+	}
+	// MintRewardsMsg mints the specified number of block rewards,
+	// and sends them to the specified recipient (typically, the staking contract)
+	MintRewardsMsg struct {
+		Amount    wasmvmtypes.Coin `json:"amount"`
+		Recipient string           `json:"recipient"`
+	}
+)

--- a/x/babylon/keeper/handler_plugin.go
+++ b/x/babylon/keeper/handler_plugin.go
@@ -55,7 +55,7 @@ func (h CustomMsgHandler) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddre
 	if err := json.Unmarshal(msg.Custom, &customMsg); err != nil {
 		return nil, nil, nil, sdkerrors.ErrJSONUnmarshal.Wrap("custom message")
 	}
-	if customMsg.Test == nil {
+	if customMsg.MintRewards == nil {
 		// not our message type
 		return nil, nil, nil, wasmtypes.ErrUnknownMsg
 	}
@@ -64,10 +64,10 @@ func (h CustomMsgHandler) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddre
 		return nil, nil, nil, sdkerrors.ErrUnauthorized.Wrapf("contract has no permission for Babylon operations")
 	}
 
-	return h.handleTestMsg(ctx, contractAddr, customMsg.Test)
+	return h.handleMintRewardsMsg(ctx, contractAddr, customMsg.MintRewards)
 }
 
-func (h CustomMsgHandler) handleTestMsg(ctx sdk.Context, actor sdk.AccAddress, testMsg *contract.TestMsg) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
+func (h CustomMsgHandler) handleMintRewardsMsg(ctx sdk.Context, actor sdk.AccAddress, mintRewardsMsg *contract.MintRewardsMsg) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
 	return []sdk.Event{}, nil, nil, nil
 }
 

--- a/x/babylon/keeper/handler_plugin.go
+++ b/x/babylon/keeper/handler_plugin.go
@@ -86,21 +86,9 @@ func (h CustomMsgHandler) handleMintRewardsMsg(ctx sdk.Context, actor sdk.AccAdd
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if err != nil {
-		return nil, nil, nil, err
-	}
 
-	rewards, err := h.k.MintBlockRewards(ctx, recipient, coin)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	return []sdk.Event{sdk.NewEvent(
-		types.EventTypeMintRewards,
-		sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-		sdk.NewAttribute(sdk.AttributeKeySender, actor.String()),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, rewards.String()),
-	)}, nil, nil, nil
+	_, err = h.k.MintBlockRewards(ctx, recipient, coin)
+	return nil, nil, nil, err
 }
 
 // AuthSourceFn is helper for simple AuthSource types

--- a/x/babylon/keeper/mint_rewards.go
+++ b/x/babylon/keeper/mint_rewards.go
@@ -1,0 +1,56 @@
+package keeper
+
+import (
+	sdkmath "cosmossdk.io/math"
+	"github.com/babylonlabs-io/babylon-sdk/x/babylon/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// MintBlockRewards mints new "virtual" bonding tokens and sends them to the staking contract for distribution.
+// The amount minted is removed from the SupplyOffset (so that it will become negative), when supported.
+// Authorization of the actor/recipient should be handled before entering this method.
+// The amount is computed based on the finality inflation rate and the total staking token supply, in the bonded denom
+func (k Keeper) MintBlockRewards(pCtx sdk.Context, recipient sdk.AccAddress, amt sdk.Coin) (sdkmath.Int, error) {
+	if amt.Amount.IsNil() || amt.Amount.IsZero() || amt.Amount.IsNegative() {
+		return sdkmath.ZeroInt(), errors.ErrInvalidRequest.Wrap("amount")
+	}
+
+	// Ensure staking constraints
+	bondDenom, err := k.Staking.BondDenom(pCtx)
+	if err != nil {
+		return sdkmath.ZeroInt(), err
+	}
+	if amt.Denom != bondDenom {
+		return sdkmath.ZeroInt(), errors.ErrInvalidRequest.Wrapf("invalid coin denomination: got %s, expected %s", amt.Denom, bondDenom)
+	}
+	// FIXME? Remove this constraint for flexibility
+	params := k.GetParams(pCtx)
+	if recipient.String() != params.BtcStakingContractAddress {
+		return sdkmath.ZeroInt(), errors.ErrUnauthorized.Wrapf("invalid recipient: got %s, expected staking contract (%s)",
+			recipient, params.BtcStakingContractAddress)
+	}
+
+	// TODO?: Ensure Babylon constraints
+
+	cacheCtx, done := pCtx.CacheContext() // work in a cached store as Osmosis (safety net?)
+
+	// Mint rewards tokens
+	coins := sdk.NewCoins(amt)
+	err = k.bank.MintCoins(cacheCtx, types.ModuleName, coins)
+	if err != nil {
+		return sdkmath.ZeroInt(), err
+	}
+
+	// FIXME: Confirm we want this supply offset enabled for rewards, i.e.
+	// as virtual coins that do not count to the total supply
+	//k.bank.AddSupplyOffset(cacheCtx, bondDenom, amt.Amount.Neg())
+
+	err = k.bank.SendCoinsFromModuleToAccount(cacheCtx, types.ModuleName, recipient, coins)
+	if err != nil {
+		return sdkmath.ZeroInt(), err
+	}
+
+	done()
+	return amt.Amount, err
+}

--- a/x/babylon/keeper/mint_rewards.go
+++ b/x/babylon/keeper/mint_rewards.go
@@ -7,10 +7,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-// MintBlockRewards mints new "virtual" bonding tokens and sends them to the staking contract for distribution.
-// The amount minted is removed from the SupplyOffset (so that it will become negative), when supported.
-// Authorization of the actor/recipient should be handled before entering this method.
-// The amount is computed based on the finality inflation rate and the total staking token supply, in the bonded denom
+// MintBlockRewards mints new tokens and sends them to the staking contract for distribution.
+// Authorization of the actor should be handled before entering this method.
+// Authorization of the recipient is being handled within the method for safety, but can
+// be removed for flexibility
 func (k Keeper) MintBlockRewards(pCtx sdk.Context, recipient sdk.AccAddress, amt sdk.Coin) (sdkmath.Int, error) {
 	if amt.Amount.IsNil() || amt.Amount.IsZero() || amt.Amount.IsNegative() {
 		return sdkmath.ZeroInt(), errors.ErrInvalidRequest.Wrap("amount")

--- a/x/babylon/types/events.go
+++ b/x/babylon/types/events.go
@@ -12,6 +12,7 @@ const (
 	EventTypeMaxCapLimitUpdated  = "max_cap_limit_updated"
 	EventTypeUnbond              = "instant_unbond"
 	EventTypeDelegate            = "instant_delegate"
+	EventTypeMintRewards         = "mint_rewards"
 )
 
 const (

--- a/x/babylon/types/expected_keepers.go
+++ b/x/babylon/types/expected_keepers.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	context "context"
+	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -18,6 +19,8 @@ type BankKeeper interface {
 
 // StakingKeeper expected staking keeper.
 type StakingKeeper interface {
+	BondDenom(ctx context.Context) (string, error)
+	StakingTokenSupply(ctx context.Context) (sdkmath.Int, error)
 }
 
 // AccountKeeper interface contains functions for getting accounts and the module address


### PR DESCRIPTION
Thin layer impl of the finalisation block rewards generation. Supersedes / replaces #61.

**TODO**: To be done in a follow-up PR.

- [ ] ~Contracts integration / update.~
- [ ] ~Enable Grpc queries in the `x/wasm` module (used by the `btc-finality` contract to get the blocks per year param from the mint module.~
- [ ] ~E2e tests~.
