### PR TITLE
chore: reduce e2e runtime

### DIFF
--- a/contrib/images/ibcsim-bcd/wrapper.sh
+++ b/contrib/images/ibcsim-bcd/wrapper.sh
@@ -94,4 +94,4 @@ rly --home $RELAYER_CONF_DIR tx link bcd --src-port transfer --dst-port transfer
 sleep 10
 
 echo "Start the IBC relayer"
-rly --home $RELAYER_CONF_DIR start bcd --debug-addr "" --flush-interval 30s
+rly --home $RELAYER_CONF_DIR start bcd --debug-addr "" --flush-interval 10s

--- a/tests/e2e/bcd_consumer_integration_test.go
+++ b/tests/e2e/bcd_consumer_integration_test.go
@@ -696,13 +696,6 @@ func (s *BCDConsumerIntegrationTestSuite) Test09ConsumerFPCascadedSlashing() {
 		return true
 	}, time.Minute, time.Second*5)
 
-	// once the vote is cast, ensure block is finalised
-	finalizedBlock, err := s.cosmwasmController.QueryIndexedBlock(consumerLatestBlockHeight)
-	s.NoError(err)
-	s.NotEmpty(finalizedBlock)
-	s.Equal(finalizedBlock.AppHash, czLatestBlock.AppHash)
-	s.True(finalizedBlock.Finalized)
-
 	// consumer finality provider submits invalid finality signature
 	txResp, err = s.cosmwasmController.SubmitInvalidFinalitySig(
 		r,

--- a/tests/e2e/bcd_consumer_integration_test.go
+++ b/tests/e2e/bcd_consumer_integration_test.go
@@ -288,7 +288,6 @@ func (s *BCDConsumerIntegrationTestSuite) Test05RestakeDelegationToMultipleFPs()
 	// register a babylon finality provider
 	babylonFp := s.createVerifyBabylonFP(babylonFpBTCSK)
 	// commit and finalize pub rand so Babylon FP has voting power
-	// TODO: is this needed?
 	randList := s.commitAndFinalizePubRand(babylonFpBTCSK, babylonFpBTCPK, uint64(1))
 	randListInfo1 = randList
 
@@ -768,7 +767,6 @@ func (s *BCDConsumerIntegrationTestSuite) Test10ConsumerDelegationExpiry() {
 	babylonFp := s.createVerifyBabylonFP(babylonFpBTCSK3)
 
 	// commit and finalize pub rand so Babylon FP has voting power
-	// TODO: is this needed?
 	currentHeight, err := s.babylonController.GetCurrentHeight()
 	s.NoError(err)
 	s.commitAndFinalizePubRand(babylonFpBTCSK3, babylonFpBTCPK3, uint64(currentHeight))
@@ -1363,7 +1361,7 @@ func (s *BCDConsumerIntegrationTestSuite) registerVerifyConsumer() *bsctypes.Con
 func (s *BCDConsumerIntegrationTestSuite) finalizeUntilConsumerHeight(consumerHeight uint64) {
 	s.Eventually(func() bool {
 		s.finalizeNextEpoch()
-		consumerLastTimestampedHeader, err := s.cosmwasmController.QuertLastBTCTimestampedHeader()
+		consumerLastTimestampedHeader, err := s.cosmwasmController.QueryLastBTCTimestampedHeader()
 		s.NoError(err)
 		s.NotNil(consumerLastTimestampedHeader)
 

--- a/tests/e2e/bcd_consumer_integration_test.go
+++ b/tests/e2e/bcd_consumer_integration_test.go
@@ -571,13 +571,6 @@ func (s *BCDConsumerIntegrationTestSuite) Test08BabylonFPCascadedSlashing() {
 	s.Equal(1, len(votes))
 	s.Equal(votes[0].MarshalHex(), babylonFpBIP340PK.MarshalHex())
 
-	// once the vote is cast, ensure block is finalised
-	finalizedBlock, err := s.babylonController.QueryIndexedBlock(firstNonFinalizedHeight)
-	s.NoError(err)
-	s.NotEmpty(finalizedBlock)
-	s.Equal(strings.ToUpper(hex.EncodeToString(finalizedBlock.AppHash)), firstNonFinalizedBlock.Block.AppHash.String())
-	s.True(finalizedBlock.Finalized)
-
 	// equivocate by submitting invalid finality signature
 	_, err = s.babylonController.SubmitInvalidFinalitySignature(
 		r,
@@ -702,6 +695,13 @@ func (s *BCDConsumerIntegrationTestSuite) Test09ConsumerFPCascadedSlashing() {
 		}
 		return true
 	}, time.Minute, time.Second*5)
+
+	// once the vote is cast, ensure block is finalised
+	finalizedBlock, err := s.cosmwasmController.QueryIndexedBlock(consumerLatestBlockHeight)
+	s.NoError(err)
+	s.NotEmpty(finalizedBlock)
+	s.Equal(finalizedBlock.AppHash, czLatestBlock.AppHash)
+	s.True(finalizedBlock.Finalized)
 
 	// consumer finality provider submits invalid finality signature
 	txResp, err = s.cosmwasmController.SubmitInvalidFinalitySig(

--- a/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/cosmwasm.go
+++ b/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/cosmwasm.go
@@ -1049,7 +1049,7 @@ func (cc *CosmwasmConsumerController) createGrpcConnection() (*grpc.ClientConn, 
 	return grpcConn, nil
 }
 
-func (cc *CosmwasmConsumerController) QuertLastBTCTimestampedHeader() (*CzHeaderResponse, error) {
+func (cc *CosmwasmConsumerController) QueryLastBTCTimestampedHeader() (*CzHeaderResponse, error) {
 	queryMsgStruct := QueryMsgCzLastHeader{
 		CzLastHeader: struct{}{},
 	}

--- a/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/cosmwasm.go
+++ b/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/cosmwasm.go
@@ -196,7 +196,7 @@ func (cc *CosmwasmConsumerController) SubmitInvalidFinalitySig(
 	privateRand *eots.PrivateRand,
 	pubRand *bbntypes.SchnorrPubRand,
 	proof *cmtcrypto.Proof,
-	heightToVote int64,
+	heightToVote uint64,
 ) (*types.TxResponse, error) {
 	invalidAppHash := datagen.GenRandomByteArray(r, 32)
 	invalidMsgToSign := append(sdk.Uint64ToBigEndian(uint64(heightToVote)), invalidAppHash...)
@@ -208,7 +208,7 @@ func (cc *CosmwasmConsumerController) SubmitInvalidFinalitySig(
 
 	submitFinalitySig := &SubmitFinalitySignature{
 		FpPubkeyHex: bbntypes.NewBIP340PubKeyFromBTCPK(fpBtcPk).MarshalHex(),
-		Height:      uint64(heightToVote),
+		Height:      heightToVote,
 		PubRand:     pubRand.MustMarshal(),
 		Proof: Proof{
 			Total:    proof.Total,

--- a/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/cosmwasm.go
+++ b/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/cosmwasm.go
@@ -1048,3 +1048,26 @@ func (cc *CosmwasmConsumerController) createGrpcConnection() (*grpc.ClientConn, 
 	}
 	return grpcConn, nil
 }
+
+func (cc *CosmwasmConsumerController) QuertLastBTCTimestampedHeader() (*CzHeaderResponse, error) {
+	queryMsgStruct := QueryMsgCzLastHeader{
+		CzLastHeader: struct{}{},
+	}
+	queryMsgBytes, err := json.Marshal(queryMsgStruct)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal query message: %v", err)
+	}
+
+	dataFromContract, err := cc.QuerySmartContractState(cc.cfg.BabylonContractAddress, string(queryMsgBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query smart contract state: %w", err)
+	}
+
+	var resp CzHeaderResponse
+	err = json.Unmarshal(dataFromContract.Data, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &resp, nil
+}

--- a/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/msg.go
+++ b/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/msg.go
@@ -1,6 +1,8 @@
 package cosmwasm
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 type ConsumerFpsResponse struct {
 	Fps []SingleConsumerFpResponse `json:"fps"`
@@ -308,4 +310,19 @@ type SinglePendingRewardsResponse struct {
 	StakingTxHash []byte   `json:"staking_tx_hash"`
 	FpPubkeyHex   string   `json:"fp_pubkey_hex"`
 	Rewards       sdk.Coin `json:"rewards"`
+}
+
+type QueryMsgCzLastHeader struct {
+	CzLastHeader struct{} `json:"cz_last_header"`
+}
+
+type CzHeaderResponse struct {
+	ConsumerID          string `json:"consumer_id"`
+	Hash                string `json:"hash"`
+	Height              uint64 `json:"height"`
+	Time                int64  `json:"time,omitempty"`
+	BabylonHeaderHash   string `json:"babylon_header_hash"`
+	BabylonHeaderHeight uint64 `json:"babylon_header_height"`
+	BabylonEpoch        uint64 `json:"babylon_epoch"`
+	BabylonTxHash       string `json:"babylon_tx_hash"`
 }

--- a/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/msg.go
+++ b/tests/e2e/cosmos-integration-e2e/clientcontroller/cosmwasm/msg.go
@@ -320,7 +320,7 @@ type CzHeaderResponse struct {
 	ConsumerID          string `json:"consumer_id"`
 	Hash                string `json:"hash"`
 	Height              uint64 `json:"height"`
-	Time                int64  `json:"time,omitempty"`
+	Time                string `json:"time,omitempty"`
 	BabylonHeaderHash   string `json:"babylon_header_hash"`
 	BabylonHeaderHeight uint64 `json:"babylon_header_height"`
 	BabylonEpoch        uint64 `json:"babylon_epoch"`


### PR DESCRIPTION
- Add query for getting last timestamped header in consumer
- Add helper function for timestamping consumer until a given height
- Reduce e2e test runtime using these functions