### PR TITLE
ci: parallise docker build

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,14 @@ on:
     branches:
     - '**'
 
+# Set default permissions for all jobs
+permissions: read-all
+
 jobs:
   setup:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,6 +23,8 @@ jobs:
   build-ibcsim:
     needs: setup
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,6 +34,8 @@ jobs:
   build-babylond:
     needs: setup
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,6 +45,8 @@ jobs:
   e2e-test:
     needs: [build-ibcsim, build-babylond]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,51 +4,72 @@ on:
     branches:
     - '**'
 
-# Set default permissions for all jobs
+concurrency:
+  group: e2e-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:
-  setup:
+  e2e-docker-build-ibcsim:
     runs-on: ubuntu-22.04
-    permissions:
-      contents: read
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Build docker ibcsim-bcd
+        run: |
+          make build-ibcsim-bcd
+      - name: Docker save ibcsim
+        run: |
+          docker save -o /tmp/docker-ibcsim.tar.gz babylonlabs-io/ibcsim-bcd:latest
+      - name: Upload ibcsim artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibcsim-${{ github.sha }}
+          path: /tmp/docker-ibcsim.tar.gz
+
+  e2e-docker-build-babylond:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build docker babylond
+        run: |
+          make build-babylond
+      - name: Docker save babylond
+        run: |
+          docker save -o /tmp/docker-babylond.tar.gz babylonlabs-io/babylond:latest
+      - name: Upload babylond artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: babylond-${{ github.sha }}
+          path: /tmp/docker-babylond.tar.gz
+
+  e2e-test:
+    needs: [e2e-docker-build-ibcsim, e2e-docker-build-babylond]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download ibcsim artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ibcsim-${{ github.sha }}
+          path: /tmp
+      - name: Download babylond artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: babylond-${{ github.sha }}
+          path: /tmp
+      - name: Docker load ibcsim
+        run: |
+          docker load < /tmp/docker-ibcsim.tar.gz
+      - name: Docker load babylond
+        run: |
+          docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23
-
-  build-ibcsim:
-    needs: setup
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Build ibcsim-bcd
-        run: sudo make build-ibcsim-bcd
-
-  build-babylond:
-    needs: setup
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Build babylond
-        run: sudo make build-babylond
-
-  e2e-test:
-    needs: [build-ibcsim, build-babylond]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Run E2E Tests
         run: sudo make test-e2e-cache

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
     - '**'
 
 jobs:
-  test:
+  setup:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
@@ -14,5 +14,30 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23
+
+  build-ibcsim:
+    needs: setup
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build ibcsim-bcd
+        run: sudo make build-ibcsim-bcd
+
+  build-babylond:
+    needs: setup
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build babylond
+        run: sudo make build-babylond
+
+  e2e-test:
+    needs: [build-ibcsim, build-babylond]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Run E2E Tests
-        run: sudo make test-e2e
+        run: sudo make test-e2e-cache


### PR DESCRIPTION
This PR parallelises building two Docker images in CI. Now e2e CI takes ~20min as opposed to 24min