### PR TITLE
chore: fix publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,6 @@ jobs:
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.2
     with:
       run-unit-tests: true
-      run-integration-tests: true
-      integration-tests-command: |
-        make test-integration
       
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2


### PR DESCRIPTION
This PR fixes a bug in publish CI 

Failed CI example https://github.com/babylonlabs-io/babylon-sdk/actions/runs/16640682595/job/47090307469