### PR TITLE
bugfix: cacheContext not passed to sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#219](https://github.com/babylonlabs-io/babylon-sdk/pull/219) bugfix: 
+  cacheContext not passed to sudo
 - [#217](https://github.com/babylonlabs-io/babylon-sdk/pull/217) chore: fix go
   mod
 - [#215](https://github.com/babylonlabs-io/babylon-sdk/pull/215) chore: bump


### PR DESCRIPTION
## Description

This PR ensures that we always work with a `cachedContext` when executing sudo logic. The store will only be updated if execution completes successfully (no error or panic). This prevents partial writes and ensures state consistency.

## Why it matters
Without using a `CacheContext`, passing a plain `ctx (sdk.UnwrapSDKContext(c))` means that any call to `store.set` or save inside a contract is written directly to the persistent `MultiStore`. This creates the risk of partial state commits:
```
BLOCKS.save(store, block.height, block)?;    // committed
// Out of gas happens here
NEXT_HEIGHT.save(store, &(block.height + 1))?;   // never reached
```
If an out-of-gas panic occurs after the first save, your defer may recover and return an error, but the earlier write has already been persisted. This leaves the chain in an inconsistent or unexpected state.

## Solution
By wrapping the context with CacheContext, all writes are applied to a cached store. Only if execution completes without errors or panics do we commit the changes back to the main store. If an error or panic is encountered, the cached writes are discarded, ensuring atomicity of state changes.