### PR TITLE
chore: update reusable docker pipeline to v0.16.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
     tags:
     - '*'
   workflow_dispatch:
-  
+
 permissions:
   contents: read
 
@@ -17,9 +17,9 @@ jobs:
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.2
     with:
       run-unit-tests: true
-      
+
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@a5bf0dd12c945ee8fb95cd18765f134928de3e32 # v0.16.0
     needs: ["test"]
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Updates `reusable_docker_pipeline.yml` to v0.16.0 (`a5bf0dd`).

This version introduces pre-push security scanning — images are scanned
for vulnerabilities and secrets *before* being pushed to registries.

### What changes in v0.16.0

- **Scan-before-push**: Trivy filesystem + image scans run before any registry push
- **Secret scanning**: source code and image layer secret detection
- **Scans enabled by default**: `docker_scan: true`, `trivy_nofail: false`, `hadolint_nofail: false`
- **DockerHub push disabled by default**: `push_to_dockerhub` now defaults to `false`
- **Job Summary**: scan results appear directly in the GitHub Actions run summary
- **SARIF upload**: vulnerability findings surface in GitHub Security tab (public repos)
- **Build caching**: scan build layers are reused via `cache-from` for push steps

