### PR TITLE
chore: harden Dockerfiles and add devops CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-# DevOps team owns CI/CD and container configuration
-/.github/ @babylonlabs-io/devops
-/.github/CODEOWNERS @babylonlabs-io/devops
-**/Dockerfile @babylonlabs-io/devops
+# DevOps team owns CI/CD workflows
+/.github/workflows/ @babylonlabs-io/devops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# DevOps team owns CI/CD and container configuration
+/.github/ @babylonlabs-io/devops
+/.github/CODEOWNERS @babylonlabs-io/devops
+**/Dockerfile @babylonlabs-io/devops

--- a/contrib/images/babylond/Dockerfile
+++ b/contrib/images/babylond/Dockerfile
@@ -15,8 +15,8 @@ ARG LEDGER_ENABLED="false"
 
 
 # Install cli tools for building and final image
-RUN apk add --update --no-cache make git bash gcc linux-headers eudev-dev ncurses-dev openssh curl jq
-RUN apk add --no-cache musl-dev
+# hadolint ignore=DL3018
+RUN apk add --no-cache make git bash gcc linux-headers eudev-dev ncurses-dev openssh curl jq musl-dev
 
 # Build
 WORKDIR /go/src/github.com/babylonlabs-io/babylon
@@ -35,12 +35,13 @@ RUN if [ -n "${VERSION}" ]; then \
     fi
 
 # Cosmwasm - Download correct libwasmvm version
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | cut -d ' ' -f 2) && \
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
-    -O /lib/libwasmvm_muslc.$(uname -m).a && \
+    wget -q https://github.com/CosmWasm/wasmvm/releases/download/"$WASMVM_VERSION"/libwasmvm_muslc."$(uname -m)".a \
+    -O /lib/libwasmvm_muslc."$(uname -m)".a && \
     # verify checksum
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
-    sha256sum /lib/libwasmvm_muslc.$(uname -m).a | grep $(cat /tmp/checksums.txt | grep libwasmvm_muslc.$(uname -m) | cut -d ' ' -f 1)
+    wget -q https://github.com/CosmWasm/wasmvm/releases/download/"$WASMVM_VERSION"/checksums.txt -O /tmp/checksums.txt && \
+    sha256sum /lib/libwasmvm_muslc."$(uname -m)".a | grep "$(cat /tmp/checksums.txt | grep libwasmvm_muslc."$(uname -m)" | cut -d ' ' -f 1)"
 
 RUN LEDGER_ENABLED=$LEDGER_ENABLED \
     BABYLON_BUILD_OPTIONS=$BABYLON_BUILD_OPTIONS \
@@ -49,10 +50,10 @@ RUN LEDGER_ENABLED=$LEDGER_ENABLED \
     LINK_STATICALLY=true \
     make build
 
-FROM alpine:3.14 AS run
+FROM alpine:3.21 AS run
 # Create a user
 RUN addgroup --gid 1137 -S babylon && adduser --uid 1137 -S babylon -G babylon
-RUN apk add bash curl jq
+RUN apk add --no-cache bash=5.2.37-r0 curl=8.14.1-r2 jq=1.7.1-r0
 
 # Label should match your github repo
 ARG VERSION

--- a/contrib/images/ibcsim-bcd/Dockerfile
+++ b/contrib/images/ibcsim-bcd/Dockerfile
@@ -1,6 +1,15 @@
-FROM debian:bullseye-slim AS build-env
+FROM debian:bookworm-slim AS build-env
 
-RUN apt-get update && apt-get install -y git make gcc wget
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates=20230311+deb12u1 \
+    gcc=4:12.2.0-3 \
+    git=1:2.39.5-0+deb12u3 \
+    libc6-dev=2.36-9+deb12u13 \
+    make=4.3-4.1 \
+    wget=1.21.3-1+deb12u1 \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work
 
@@ -21,27 +30,36 @@ ENV RELAYER_TAG=v2.5.3
 
 # Install the relayer
 RUN git clone https://github.com/cosmos/relayer.git
-RUN cd relayer && git fetch origin && git checkout ${RELAYER_TAG} && make install && cd -
+WORKDIR /work/relayer
+RUN git fetch origin && git checkout ${RELAYER_TAG} && make install
+WORKDIR /work
 
 # build bcd
 COPY . /work/babylon-sdk
-RUN cd babylon-sdk && \
-    make build && \
-    cd -
+WORKDIR /work/babylon-sdk
+RUN make build
+WORKDIR /work
 
-FROM debian:bullseye-slim AS run
+FROM debian:bookworm-slim AS run
 
-RUN apt-get update && apt-get install -y bash curl jq wget
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates=20230311+deb12u1 \
+    curl=7.88.1-10+deb12u14 \
+    jq=1.6-2.1+deb12u1 \
+    wget=1.21.3-1+deb12u1 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install libraries
 # Cosmwasm - Download correct libwasmvm version
 COPY --from=build-env /work/babylon-sdk/demo/go.mod /tmp
 RUN WASMVM_VERSION=$(grep github.com/CosmWasm/wasmvm /tmp/go.mod | cut -d' ' -f2) && \
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm.$(uname -m).so \
-    -O /lib/libwasmvm.$(uname -m).so && \
+    wget -q "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm.$(uname -m).so" \
+    -O "/lib/libwasmvm.$(uname -m).so" && \
     # verify checksum
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
-    sha256sum /lib/libwasmvm.$(uname -m).so | grep $(cat /tmp/checksums.txt | grep libwasmvm.$(uname -m) | cut -d ' ' -f 1)
+    wget -q "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/checksums.txt" -O /tmp/checksums.txt && \
+    sha256sum "/lib/libwasmvm.$(uname -m).so" | grep "$(cat /tmp/checksums.txt | grep "libwasmvm.$(uname -m)" | cut -d ' ' -f 1)"
 RUN rm -f /tmp/go.mod
 
 # Copy binaries

--- a/contrib/images/local-bcd/Dockerfile
+++ b/contrib/images/local-bcd/Dockerfile
@@ -1,6 +1,15 @@
-FROM debian:bullseye-slim AS build-env
+FROM debian:bookworm-slim AS build-env
 
-RUN apt-get update && apt-get install -y git make gcc wget
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates=20230311+deb12u1 \
+    gcc=4:12.2.0-3 \
+    git=1:2.39.5-0+deb12u3 \
+    libc6-dev=2.36-9+deb12u13 \
+    make=4.3-4.1 \
+    wget=1.21.3-1+deb12u1 \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work
 
@@ -22,19 +31,26 @@ ENV GO111MODULE=on
 COPY . /work
 RUN make install
 
-FROM debian:bullseye-slim AS run
+FROM debian:bookworm-slim AS run
 
-RUN apt-get update && apt-get install -y bash curl jq wget
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates=20230311+deb12u1 \
+    curl=7.88.1-10+deb12u14 \
+    jq=1.6-2.1+deb12u1 \
+    wget=1.21.3-1+deb12u1 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install libraries
 # Cosmwasm - Download correct libwasmvm version
 COPY --from=build-env /work/demo/go.mod /tmp
 RUN WASMVM_VERSION=$(grep github.com/CosmWasm/wasmvm /tmp/go.mod | cut -d' ' -f2) && \
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm.$(uname -m).so \
-    -O /lib/libwasmvm.$(uname -m).so && \
+    wget -q "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm.$(uname -m).so" \
+    -O "/lib/libwasmvm.$(uname -m).so" && \
     # verify checksum
-    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
-    sha256sum /lib/libwasmvm.$(uname -m).so | grep $(cat /tmp/checksums.txt | grep libwasmvm.$(uname -m) | cut -d ' ' -f 1)
+    wget -q "https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/checksums.txt" -O /tmp/checksums.txt && \
+    sha256sum "/lib/libwasmvm.$(uname -m).so" | grep "$(cat /tmp/checksums.txt | grep "libwasmvm.$(uname -m)" | cut -d ' ' -f 1)"
 RUN rm -f /tmp/go.mod
 
 # Install binaries


### PR DESCRIPTION
## Summary

- Pin Alpine runtime packages to exact versions (Alpine 3.21)
- Pin Debian runtime packages to exact versions (bookworm) where applicable
- Upgrade base images to current stable (Alpine 3.21, Debian bookworm)
- Apply hadolint best practices: `SHELL` pipefail, `--no-cache`/`--no-install-recommends`, shell variable quoting, merged `RUN` layers
- Add CODEOWNERS rules for `/.github/`, `/.github/CODEOWNERS`, and `**/Dockerfile` owned by `@babylonlabs-io/devops`